### PR TITLE
Remove unnecessary commons-compress override since Testcontainers 2.0…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,6 @@
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-impl-base</artifactId>
         </dependency>
-        <!-- To avoid a CVE. This can be removed once TC is updated -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.28.0</version>
-        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>


### PR DESCRIPTION
….4 already depends on 1.28.0