### PR TITLE
Add named container lookup to support multiple containers of the same…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,13 @@
             <organization>Red Hat, Inc.</organization>
             <organizationUrl>https://redhat.com</organizationUrl>
         </developer>
+        <developer>
+            <id>rhusar</id>
+            <name>Radoslav Husar</name>
+            <email>rhusar@redhat.com</email>
+            <organization>Red Hat, Inc.</organization>
+            <organizationUrl>https://redhat.com</organizationUrl>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/java/org/arquillian/testcontainers/TestcontainerDescription.java
+++ b/src/main/java/org/arquillian/testcontainers/TestcontainerDescription.java
@@ -19,6 +19,12 @@ class TestcontainerDescription {
      * The annotation that was on the field
      */
     final Testcontainer testcontainer;
+
+    /**
+     * The name of the container, or an empty string for unnamed containers
+     */
+    final String name;
+
     /**
      * The instance of the container created
      */
@@ -26,6 +32,7 @@ class TestcontainerDescription {
 
     TestcontainerDescription(final Testcontainer testcontainer, final GenericContainer<?> instance) {
         this.testcontainer = testcontainer;
+        this.name = testcontainer.name();
         this.instance = instance;
     }
 }

--- a/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
+++ b/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
@@ -69,11 +69,33 @@ class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
      */
     GenericContainer<?> lookup(final String name) {
         for (TestcontainerDescription containerDesc : this.containers) {
-            if (name.equals(containerDesc.name)) {
+            if (containerDesc.name.equals(name)) {
                 return containerDesc.instance;
             }
         }
         return null;
+    }
+
+    /**
+     * Typed lookup by name. Throws {@link IllegalArgumentException} if a container with the given name is registered
+     * but its runtime type is not assignable to {@code type}.
+     *
+     * @param name the container name
+     * @param type the expected container type
+     *
+     * @return the container cast to {@code type}, or {@code null} if no container with the given name is registered
+     */
+    <T extends GenericContainer<?>> T lookup(final String name, final Class<T> type) {
+        final GenericContainer<?> container = lookup(name);
+        if (container == null) {
+            return null;
+        }
+        if (!type.isInstance(container)) {
+            throw new IllegalArgumentException(
+                    String.format("Container with name '%s' is of type %s, which is not assignable to %s",
+                            name, container.getClass().getName(), type.getName()));
+        }
+        return type.cast(container);
     }
 
     /**

--- a/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
+++ b/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
@@ -37,17 +37,43 @@ class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
      */
     GenericContainer<?> lookupOrCreate(final Class<GenericContainer<?>> type, final Testcontainer testcontainer,
             final List<Annotation> qualifiers) {
-        GenericContainer<?> result = lookup(type, qualifiers);
+        final String name = testcontainer.name();
+        GenericContainer<?> result = name.isEmpty() ? lookup(type, qualifiers) : lookup(name);
         if (result == null) {
             try {
                 final Constructor<? extends GenericContainer<?>> constructor = getConstructor(type, testcontainer);
                 result = constructor.newInstance();
-                this.containers.add(new TestcontainerDescription(testcontainer, result));
+                final TestcontainerDescription description = new TestcontainerDescription(testcontainer, result);
+                if (!name.isEmpty()) {
+                    for (TestcontainerDescription containerDesc : this.containers) {
+                        if (name.equals(containerDesc.name)) {
+                            throw new IllegalArgumentException(
+                                    String.format("A container with name \"%s\" is already registered", name));
+                        }
+                    }
+                }
+                this.containers.add(description);
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 throw new IllegalArgumentException(String.format("Could create container %s", type.getName()), e);
             }
         }
         return result;
+    }
+
+    /**
+     * Lookup a container by name.
+     *
+     * @param name the container name
+     *
+     * @return the container instance or {@code null} if not found
+     */
+    GenericContainer<?> lookup(final String name) {
+        for (TestcontainerDescription containerDesc : this.containers) {
+            if (name.equals(containerDesc.name)) {
+                return containerDesc.instance;
+            }
+        }
+        return null;
     }
 
     /**
@@ -63,14 +89,14 @@ class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
         final List<TestcontainerDescription> foundContainers = new ArrayList<>();
         if (qualifiers.isEmpty()) {
             for (TestcontainerDescription containerDesc : this.containers) {
-                if (type.isAssignableFrom(containerDesc.instance.getClass())) {
+                if (containerDesc.name.isEmpty() && type.isAssignableFrom(containerDesc.instance.getClass())) {
                     foundContainers.add(containerDesc);
                 }
             }
         } else {
             for (TestcontainerDescription containerDesc : this.containers) {
                 for (Annotation qualifier : qualifiers) {
-                    if (type.isAssignableFrom(containerDesc.instance.getClass())
+                    if (containerDesc.name.isEmpty() && type.isAssignableFrom(containerDesc.instance.getClass())
                             && type.isAnnotationPresent(qualifier.annotationType())) {
                         foundContainers.add(containerDesc);
                     }

--- a/src/main/java/org/arquillian/testcontainers/api/Testcontainer.java
+++ b/src/main/java/org/arquillian/testcontainers/api/Testcontainer.java
@@ -56,6 +56,17 @@ public @interface Testcontainer {
     boolean value() default true;
 
     /**
+     * An optional name for the container. When set, the container is registered and looked up by this name, allowing
+     * multiple containers of the same type to coexist in a single test class.
+     * <p>
+     * If left as the default empty string, the container is looked up by type and qualifiers as usual.
+     * </p>
+     *
+     * @return the name of the container, or an empty string for unnamed containers
+     */
+    String name() default "";
+
+    /**
      * The type used to create the value for the field. The type must have a no-arg constructor.
      * <p>
      * If left as the default value, {@link GenericContainer}, the type to construct is derived from the

--- a/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
+++ b/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.arquillian.testcontainers;
+
+import org.arquillian.testcontainers.api.Testcontainer;
+import org.arquillian.testcontainers.api.TestcontainersRequired;
+import org.arquillian.testcontainers.common.SimpleTestContainer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opentest4j.TestAbortedException;
+
+@ExtendWith(ArquillianExtension.class)
+@TestcontainersRequired(TestAbortedException.class)
+@RunAsClient
+public class NamedContainerTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Testcontainer(name = "first")
+    private SimpleTestContainer first;
+
+    @Testcontainer(name = "second")
+    private SimpleTestContainer second;
+
+    @Testcontainer
+    private SimpleTestContainer unnamed;
+
+    @Test
+    public void checkAllInjected() {
+        Assertions.assertNotNull(first, "Expected the first container to be injected.");
+        Assertions.assertNotNull(second, "Expected the second container to be injected.");
+        Assertions.assertNotNull(unnamed, "Expected the unnamed container to be injected.");
+    }
+
+    @Test
+    public void checkAllRunning() {
+        Assertions.assertTrue(first.isRunning(), "Expected the first container to be running.");
+        Assertions.assertTrue(second.isRunning(), "Expected the second container to be running.");
+        Assertions.assertTrue(unnamed.isRunning(), "Expected the unnamed container to be running.");
+    }
+
+    @Test
+    public void checkAllDifferentInstances() {
+        Assertions.assertNotSame(first, second, "Expected named containers to be different instances.");
+        Assertions.assertNotSame(first, unnamed, "Expected named and unnamed containers to be different instances.");
+        Assertions.assertNotSame(second, unnamed, "Expected named and unnamed containers to be different instances.");
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
+++ b/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
@@ -33,6 +33,9 @@ public class NamedContainerTest {
     @Testcontainer(name = "first")
     private SimpleTestContainer first;
 
+    @Testcontainer(name = "first")
+    private SimpleTestContainer firstAgain;
+
     @Testcontainer(name = "second")
     private SimpleTestContainer second;
 
@@ -58,5 +61,10 @@ public class NamedContainerTest {
         Assertions.assertNotSame(first, second, "Expected named containers to be different instances.");
         Assertions.assertNotSame(first, unnamed, "Expected named and unnamed containers to be different instances.");
         Assertions.assertNotSame(second, unnamed, "Expected named and unnamed containers to be different instances.");
+    }
+
+    @Test
+    public void sameNameYieldsSameInstance() {
+        Assertions.assertSame(first, firstAgain, "Fields sharing a name must resolve to the same instance.");
     }
 }

--- a/src/test/java/org/arquillian/testcontainers/TestcontainerRegistryTest.java
+++ b/src/test/java/org/arquillian/testcontainers/TestcontainerRegistryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.arquillian.testcontainers;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.arquillian.testcontainers.api.Testcontainer;
+import org.arquillian.testcontainers.common.SimpleTestContainer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Plain-JUnit unit tests for {@link TestcontainerRegistry} that exercise lookup semantics without
+ * starting any Docker containers. Annotation instances are obtained by reading the annotations off
+ * fixture fields on this class so the registry can be driven through {@code lookupOrCreate}
+ * outside an Arquillian context.
+ */
+public class TestcontainerRegistryTest {
+
+    @Testcontainer(name = "alpha")
+    private SimpleTestContainer alphaFixture;
+
+    @Test
+    public void sameNameViaLookupOrCreateReturnsSameInstance() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        GenericContainer<?> first = registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+        GenericContainer<?> second = registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        Assertions.assertSame(first, second);
+    }
+
+    @Test
+    public void lookupReturnsNullForUnknownName() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        Assertions.assertNull(registry.lookup("missing"));
+    }
+
+    @Test
+    public void emptyNameLookupDoesNotMatchNamedContainers() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        Assertions.assertNull(registry.lookup(""),
+                "Empty-string lookup should not return any registered container");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<GenericContainer<?>> simpleType() {
+        return (Class<GenericContainer<?>>) (Class<?>) SimpleTestContainer.class;
+    }
+
+    private Testcontainer annotation(final String fieldName) throws NoSuchFieldException {
+        final Field field = TestcontainerRegistryTest.class.getDeclaredField(fieldName);
+        return field.getAnnotation(Testcontainer.class);
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/TestcontainerRegistryTest.java
+++ b/src/test/java/org/arquillian/testcontainers/TestcontainerRegistryTest.java
@@ -51,6 +51,37 @@ public class TestcontainerRegistryTest {
                 "Empty-string lookup should not return any registered container");
     }
 
+    @Test
+    public void lookupTreatsNullNameAsAbsent() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        Assertions.assertNull(registry.lookup((String) null));
+    }
+
+    @Test
+    public void typedLookupReturnsTypedContainer() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        GenericContainer<?> alpha = registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        SimpleTestContainer typed = registry.lookup("alpha", SimpleTestContainer.class);
+        Assertions.assertSame(alpha, typed);
+        Assertions.assertNull(registry.lookup("missing", SimpleTestContainer.class));
+    }
+
+    @Test
+    public void typedLookupThrowsOnTypeMismatch() throws Exception {
+        TestcontainerRegistry registry = new TestcontainerRegistry();
+        registry.lookupOrCreate(simpleType(), annotation("alphaFixture"), List.of());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registry.lookup("alpha", IncompatibleContainer.class));
+    }
+
+    /** Distinct {@link GenericContainer} subtype used to exercise the type-mismatch path on typed lookup. */
+    private static class IncompatibleContainer extends GenericContainer<IncompatibleContainer> {
+    }
+
     @SuppressWarnings("unchecked")
     private static Class<GenericContainer<?>> simpleType() {
         return (Class<GenericContainer<?>>) (Class<?>) SimpleTestContainer.class;


### PR DESCRIPTION
… type

Adds a name attribute to @Testcontainer so that containers can be registered and looked up by name, allowing multiple containers of the same type to coexist in a single test class.

Part of #117