### PR TITLE
Add container lifecycle events for extension authors

### DIFF
--- a/src/main/java/org/arquillian/testcontainers/TestContainersObserver.java
+++ b/src/main/java/org/arquillian/testcontainers/TestContainersObserver.java
@@ -8,7 +8,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import org.arquillian.testcontainers.api.TestcontainersRequired;
+import org.arquillian.testcontainers.api.event.AfterTestcontainerStart;
+import org.arquillian.testcontainers.api.event.AfterTestcontainerStop;
+import org.arquillian.testcontainers.api.event.BeforeTestcontainerStart;
+import org.arquillian.testcontainers.api.event.BeforeTestcontainerStop;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -31,6 +36,18 @@ class TestContainersObserver {
 
     @Inject
     private Instance<ContainerRegistry> registry;
+
+    @Inject
+    private Event<BeforeTestcontainerStart> beforeTestcontainerStart;
+
+    @Inject
+    private Event<AfterTestcontainerStart> afterTestcontainerStart;
+
+    @Inject
+    private Event<BeforeTestcontainerStop> beforeTestcontainerStop;
+
+    @Inject
+    private Event<AfterTestcontainerStop> afterTestcontainerStop;
 
     /**
      * This first checks if the {@link TestcontainersRequired} annotation is present on the test class failing if necessary. It
@@ -69,7 +86,9 @@ class TestContainersObserver {
         TestcontainerRegistry registry = containerRegistry.get();
         if (registry != null) {
             for (TestcontainerDescription container : registry) {
+                beforeTestcontainerStop.fire(new BeforeTestcontainerStop(container.instance));
                 container.instance.stop();
+                afterTestcontainerStop.fire(new AfterTestcontainerStop(container.instance));
             }
         }
     }
@@ -86,13 +105,15 @@ class TestContainersObserver {
             // Look for the servers to start on fields only
             for (TestcontainerDescription description : registry) {
                 if (description.testcontainer.value()) {
+                    beforeTestcontainerStart.fire(new BeforeTestcontainerStart(description.instance));
                     description.instance.start();
+                    afterTestcontainerStart.fire(new AfterTestcontainerStart(description.instance));
                 }
             }
         }
     }
 
-    @SuppressWarnings({ "resource", "BooleanMethodIsAlwaysInverted" })
+    @SuppressWarnings({ "BooleanMethodIsAlwaysInverted" })
     private boolean isDockerAvailable() {
         try {
             DockerClientFactory.instance().client();

--- a/src/main/java/org/arquillian/testcontainers/api/event/AfterTestcontainerStart.java
+++ b/src/main/java/org/arquillian/testcontainers/api/event/AfterTestcontainerStart.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers.api.event;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Fired after a managed testcontainer has been started.
+ *
+ * @author Radoslav Husar
+ */
+public class AfterTestcontainerStart extends TestcontainerEvent {
+
+    public AfterTestcontainerStart(final GenericContainer<?> container) {
+        super(container);
+    }
+}

--- a/src/main/java/org/arquillian/testcontainers/api/event/AfterTestcontainerStop.java
+++ b/src/main/java/org/arquillian/testcontainers/api/event/AfterTestcontainerStop.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers.api.event;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Fired after a testcontainer has been stopped.
+ *
+ * @author Radoslav Husar
+ */
+public class AfterTestcontainerStop extends TestcontainerEvent {
+
+    public AfterTestcontainerStop(final GenericContainer<?> container) {
+        super(container);
+    }
+}

--- a/src/main/java/org/arquillian/testcontainers/api/event/BeforeTestcontainerStart.java
+++ b/src/main/java/org/arquillian/testcontainers/api/event/BeforeTestcontainerStart.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers.api.event;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Fired before a managed testcontainer is started.
+ *
+ * @author Radoslav Husar
+ */
+public class BeforeTestcontainerStart extends TestcontainerEvent {
+
+    public BeforeTestcontainerStart(final GenericContainer<?> container) {
+        super(container);
+    }
+}

--- a/src/main/java/org/arquillian/testcontainers/api/event/BeforeTestcontainerStop.java
+++ b/src/main/java/org/arquillian/testcontainers/api/event/BeforeTestcontainerStop.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers.api.event;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Fired before a testcontainer is stopped.
+ *
+ * @author Radoslav Husar
+ */
+public class BeforeTestcontainerStop extends TestcontainerEvent {
+
+    public BeforeTestcontainerStop(final GenericContainer<?> container) {
+        super(container);
+    }
+}

--- a/src/main/java/org/arquillian/testcontainers/api/event/TestcontainerEvent.java
+++ b/src/main/java/org/arquillian/testcontainers/api/event/TestcontainerEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers.api.event;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Base class for testcontainer lifecycle events.
+ *
+ * @author Radoslav Husar
+ */
+public abstract class TestcontainerEvent {
+
+    private final GenericContainer<?> container;
+
+    protected TestcontainerEvent(final GenericContainer<?> container) {
+        this.container = container;
+    }
+
+    /**
+     * Returns the container instance associated with this event.
+     *
+     * @return the container instance
+     */
+    public GenericContainer<?> getContainer() {
+        return container;
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/ContainerEventTest.java
+++ b/src/test/java/org/arquillian/testcontainers/ContainerEventTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.arquillian.testcontainers;
+
+import java.util.List;
+
+import org.arquillian.testcontainers.api.Testcontainer;
+import org.arquillian.testcontainers.api.TestcontainersRequired;
+import org.arquillian.testcontainers.api.event.AfterTestcontainerStart;
+import org.arquillian.testcontainers.api.event.BeforeTestcontainerStart;
+import org.arquillian.testcontainers.api.event.TestcontainerEvent;
+import org.arquillian.testcontainers.common.SimpleTestContainer;
+import org.arquillian.testcontainers.common.TestcontainerEventObserver;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * @author Radoslav Husar
+ */
+@ExtendWith(ArquillianExtension.class)
+@TestcontainersRequired(TestAbortedException.class)
+@RunAsClient
+public class ContainerEventTest {
+
+    @Testcontainer
+    private SimpleTestContainer container;
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void startEventsAreFired() {
+        List<TestcontainerEvent> events = TestcontainerEventObserver.events();
+        Assertions.assertTrue(events.stream().anyMatch(e -> e instanceof BeforeTestcontainerStart),
+                "Expected BeforeTestcontainerStart event");
+        Assertions.assertTrue(events.stream().anyMatch(e -> e instanceof AfterTestcontainerStart),
+                "Expected AfterTestcontainerStart event");
+    }
+
+    @Test
+    public void startEventsContainContainer() {
+        List<TestcontainerEvent> events = TestcontainerEventObserver.events();
+        for (TestcontainerEvent event : events) {
+            if (event instanceof BeforeTestcontainerStart || event instanceof AfterTestcontainerStart) {
+                Assertions.assertSame(container, event.getContainer(),
+                        "Expected event to reference the injected container");
+            }
+        }
+    }
+
+    @Test
+    public void startEventsFireInOrder() {
+        List<TestcontainerEvent> events = TestcontainerEventObserver.events();
+        int beforeIdx = -1;
+        int afterIdx = -1;
+        for (int i = 0; i < events.size(); i++) {
+            if (events.get(i) instanceof BeforeTestcontainerStart) {
+                beforeIdx = i;
+            } else if (events.get(i) instanceof AfterTestcontainerStart) {
+                afterIdx = i;
+            }
+        }
+        Assertions.assertTrue(beforeIdx >= 0, "Expected BeforeTestcontainerStart event");
+        Assertions.assertTrue(afterIdx >= 0, "Expected AfterTestcontainerStart event");
+        Assertions.assertTrue(beforeIdx < afterIdx,
+                "Expected BeforeTestcontainerStart to fire before AfterTestcontainerStart");
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/common/TestLoadableExtension.java
+++ b/src/test/java/org/arquillian/testcontainers/common/TestLoadableExtension.java
@@ -14,6 +14,7 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
 public class TestLoadableExtension implements LoadableExtension {
     @Override
     public void register(final ExtensionBuilder builder) {
-        builder.service(DeployableContainer.class, TestDeployableContainer.class);
+        builder.service(DeployableContainer.class, TestDeployableContainer.class)
+                .observer(TestcontainerEventObserver.class);
     }
 }

--- a/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
+++ b/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.arquillian.testcontainers.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.arquillian.testcontainers.api.event.AfterTestcontainerStart;
+import org.arquillian.testcontainers.api.event.AfterTestcontainerStop;
+import org.arquillian.testcontainers.api.event.BeforeTestcontainerStart;
+import org.arquillian.testcontainers.api.event.BeforeTestcontainerStop;
+import org.arquillian.testcontainers.api.event.TestcontainerEvent;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+/**
+ * @author Radoslav Husar
+ */
+@SuppressWarnings("unused")
+public class TestcontainerEventObserver {
+
+    private static final List<TestcontainerEvent> events = new ArrayList<>();
+
+    public void beforeStart(@Observes BeforeTestcontainerStart event) {
+        events.add(event);
+    }
+
+    public void afterStart(@Observes AfterTestcontainerStart event) {
+        events.add(event);
+    }
+
+    public void beforeStop(@Observes BeforeTestcontainerStop event) {
+        events.add(event);
+    }
+
+    public void afterStop(@Observes AfterTestcontainerStop event) {
+        events.add(event);
+    }
+
+    public static List<TestcontainerEvent> events() {
+        return Collections.unmodifiableList(events);
+    }
+
+    public static void clear() {
+        events.clear();
+    }
+}


### PR DESCRIPTION
Fire BeforeTestcontainerStart, AfterTestcontainerStart, BeforeTestcontainerStop, and AfterTestcontainerStop events so other Arquillian extensions can react to container lifecycle via @Observes

Resolves #117 - part 2