### PR TITLE
Issue 117 part1

### DIFF
--- a/src/main/java/org/arquillian/testcontainers/TestContainersExtension.java
+++ b/src/main/java/org/arquillian/testcontainers/TestContainersExtension.java
@@ -6,12 +6,14 @@ package org.arquillian.testcontainers;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 class TestContainersExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder
                 .observer(TestContainersObserver.class)
-                .service(TestEnricher.class, ContainerInjectionTestEnricher.class);
+                .service(TestEnricher.class, ContainerInjectionTestEnricher.class)
+                .service(ResourceProvider.class, TestcontainerRegistryResourceProvider.class);
     }
 }

--- a/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
+++ b/src/main/java/org/arquillian/testcontainers/TestcontainerRegistry.java
@@ -18,7 +18,7 @@ import org.testcontainers.containers.GenericContainer;
 /**
  * A registry to store the testcontainer descriptions.
  */
-class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
+public class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
     private final List<TestcontainerDescription> containers;
 
     TestcontainerRegistry() {
@@ -65,9 +65,13 @@ class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
      *
      * @param name the container name
      *
-     * @return the container instance or {@code null} if not found
+     * @return the container instance, or {@code null} if {@code name} is {@code null}/empty or no container with that
+     *             name is registered
      */
-    GenericContainer<?> lookup(final String name) {
+    public GenericContainer<?> lookup(final String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
         for (TestcontainerDescription containerDesc : this.containers) {
             if (containerDesc.name.equals(name)) {
                 return containerDesc.instance;
@@ -85,7 +89,7 @@ class TestcontainerRegistry implements Iterable<TestcontainerDescription> {
      *
      * @return the container cast to {@code type}, or {@code null} if no container with the given name is registered
      */
-    <T extends GenericContainer<?>> T lookup(final String name, final Class<T> type) {
+    public <T extends GenericContainer<?>> T lookup(final String name, final Class<T> type) {
         final GenericContainer<?> container = lookup(name);
         if (container == null) {
             return null;

--- a/src/main/java/org/arquillian/testcontainers/TestcontainerRegistryResourceProvider.java
+++ b/src/main/java/org/arquillian/testcontainers/TestcontainerRegistryResourceProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * Resource provider enabling {@code @ArquillianResource TestcontainerRegistry} field injection.
+ */
+public class TestcontainerRegistryResourceProvider implements ResourceProvider {
+
+    @Inject
+    private Instance<TestcontainerRegistry> registry;
+
+    @Override
+    public boolean canProvide(final Class<?> type) {
+        return TestcontainerRegistry.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object lookup(final ArquillianResource resource, final Annotation... qualifiers) {
+        final TestcontainerRegistry current = registry.get();
+        if (current == null) {
+            throw new IllegalStateException(
+                    "No TestcontainerRegistry is available in the current context. Ensure the test class is annotated with @TestcontainersRequired.");
+        }
+        return current;
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/RegistryInjectionTest.java
+++ b/src/test/java/org/arquillian/testcontainers/RegistryInjectionTest.java
@@ -7,6 +7,7 @@ package org.arquillian.testcontainers;
 import org.arquillian.testcontainers.api.Testcontainer;
 import org.arquillian.testcontainers.api.TestcontainersRequired;
 import org.arquillian.testcontainers.common.SimpleTestContainer;
+import org.arquillian.testcontainers.common.WildFlyContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -46,5 +47,18 @@ public class RegistryInjectionTest {
         Assertions.assertSame(alpha, registry.lookup("alpha"));
         Assertions.assertSame(alpha, registry.lookup("alpha", SimpleTestContainer.class));
         Assertions.assertNull(registry.lookup("missing"));
+        Assertions.assertNull(registry.lookup("missing", SimpleTestContainer.class));
+    }
+
+    @Test
+    public void lookupGuardsNullAndEmptyName() {
+        Assertions.assertNull(registry.lookup(null));
+        Assertions.assertNull(registry.lookup(""));
+    }
+
+    @Test
+    public void typedLookupRejectsMismatchedType() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> registry.lookup("alpha", WildFlyContainer.class));
     }
 }

--- a/src/test/java/org/arquillian/testcontainers/RegistryInjectionTest.java
+++ b/src/test/java/org/arquillian/testcontainers/RegistryInjectionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Arquillian Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.arquillian.testcontainers;
+
+import org.arquillian.testcontainers.api.Testcontainer;
+import org.arquillian.testcontainers.api.TestcontainersRequired;
+import org.arquillian.testcontainers.common.SimpleTestContainer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opentest4j.TestAbortedException;
+
+@ExtendWith(ArquillianExtension.class)
+@TestcontainersRequired(TestAbortedException.class)
+@RunAsClient
+public class RegistryInjectionTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Testcontainer(name = "alpha")
+    private SimpleTestContainer alpha;
+
+    @ArquillianResource
+    private TestcontainerRegistry registry;
+
+    @Test
+    public void registryIsInjected() {
+        Assertions.assertNotNull(registry, "Expected the TestcontainerRegistry to be injected");
+    }
+
+    @Test
+    public void registryResolvesByName() {
+        Assertions.assertSame(alpha, registry.lookup("alpha"));
+        Assertions.assertSame(alpha, registry.lookup("alpha", SimpleTestContainer.class));
+        Assertions.assertNull(registry.lookup("missing"));
+    }
+}

--- a/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
+++ b/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
@@ -15,6 +15,7 @@ import org.arquillian.testcontainers.spi.event.BeforeTestcontainerStart;
 import org.arquillian.testcontainers.spi.event.BeforeTestcontainerStop;
 import org.arquillian.testcontainers.spi.event.TestcontainerEvent;
 import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 
 /**
  * @author Radoslav Husar
@@ -23,6 +24,10 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 public class TestcontainerEventObserver {
 
     private static final List<TestcontainerEvent> events = new ArrayList<>();
+
+    public void clearOnNewTestClass(@Observes BeforeClass event) {
+        events.clear();
+    }
 
     public void beforeStart(@Observes BeforeTestcontainerStart event) {
         events.add(event);


### PR DESCRIPTION
Implements feature C4 of #117 

Adds @ArquillianResource support for TestcontainerRegistry, including support for programmatic lookups of injected/running containers. This enables glue code to interact with these containers (for example, looking up their ip-addresses).