### PR TITLE
fix(tests): Clear static event list in BeforeClass to fix order-depen…

### DIFF
--- a/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
+++ b/src/test/java/org/arquillian/testcontainers/NamedContainerTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opentest4j.TestAbortedException;
 
+/**
+ * @author Radoslav Husar
+ */
 @ExtendWith(ArquillianExtension.class)
 @TestcontainersRequired(TestAbortedException.class)
 @RunAsClient

--- a/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
+++ b/src/test/java/org/arquillian/testcontainers/common/TestcontainerEventObserver.java
@@ -15,14 +15,22 @@ import org.arquillian.testcontainers.spi.event.BeforeTestcontainerStart;
 import org.arquillian.testcontainers.spi.event.BeforeTestcontainerStop;
 import org.arquillian.testcontainers.spi.event.TestcontainerEvent;
 import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 
 /**
+ * Observer that collects all of {@link TestcontainerEvent}s.
+ * All events are cleared during {@link BeforeClass} event.
+ *
  * @author Radoslav Husar
  */
 @SuppressWarnings("unused")
 public class TestcontainerEventObserver {
 
     private static final List<TestcontainerEvent> events = new ArrayList<>();
+
+    public void beforeClass(@Observes BeforeClass event) {
+        events.clear();
+    }
 
     public void beforeStart(@Observes BeforeTestcontainerStart event) {
         events.add(event);
@@ -42,9 +50,5 @@ public class TestcontainerEventObserver {
 
     public static List<TestcontainerEvent> events() {
         return Collections.unmodifiableList(events);
-    }
-
-    public static void clear() {
-        events.clear();
     }
 }


### PR DESCRIPTION
…dent test failures

TestcontainerEventObserver accumulated events across test classes in a static list. When ContainerEventTest ran after other test classes assertSame failed because earlier events referenced different container instances since clear() was never being called.